### PR TITLE
Use the search limit from the settings instead of fixed

### DIFF
--- a/app/controllers/semantic_search_controller.rb
+++ b/app/controllers/semantic_search_controller.rb
@@ -10,7 +10,8 @@ class SemanticSearchController < ApplicationController
 
     if @question.present?
       search_service = SemanticSearchService.new
-      @results = search_service.search(@question, User.current, 25)
+      search_limit = Setting.plugin_semantic_search['search_limit'].to_i
+      @results = search_service.search(@question, User.current, search_limit)
     end
 
     render layout: 'base'


### PR DESCRIPTION
This PR updates the `semantic_search` Controller to use the search limit from the settings, and not use a fixed limit (25)