### PR TITLE
Use translation for API key error

### DIFF
--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -62,7 +62,7 @@ class EmbeddingService
 
   def api_key
     key = ENV.fetch("OPENAI_API_KEY", nil)
-    raise EmbeddingError, "OpenAI API key not found. Please set OPENAI_API_KEY environment variable." if key.blank?
+    raise EmbeddingError, I18n.t("error_openai_api_key_required") if key.blank?
 
     key
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,5 @@ en:
 
   project_module_semantic_search: "Semantic Search"
   permission_use_semantic_search: "Use semantic search"
+
+  error_openai_api_key_required: "OpenAI API key not found. Please set OPENAI_API_KEY environment variable."


### PR DESCRIPTION
Better to use translation instead of fixed text.