### PR TITLE
Use PCA & update maximum allowed Vector Dims

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-musl)
       racc (~> 1.4)
+    numo-linalg (0.1.7)
+      numo-narray (>= 0.9.1.4)
+    numo-narray (0.9.2.1)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -156,6 +159,8 @@ DEPENDENCIES
   concurrent-ruby (= 1.3.4)
   dotenv-rails
   neighbor
+  numo-linalg
+  numo-narray
   ruby-openai
 
 BUNDLED WITH

--- a/app/jobs/issue_embedding_job.rb
+++ b/app/jobs/issue_embedding_job.rb
@@ -30,29 +30,34 @@ class IssueEmbeddingJob < ActiveJob::Base
   def update_embedding(issue, embedding, content_hash)
     embedding_service = EmbeddingService.new
     begin
-      content = embedding_service.prepare_issue_content(issue)
-      vector, original_dimension = embedding_service.generate_embedding(content)
-
-      Rails.logger.info("=> [SEMANTIC_SEARCH] Generated embedding with dimension: #{vector.length}, original: #{original_dimension}")
-
-      vector = DimensionReductionService.validate_vector_dimension(
-        vector,
-        EmbeddingService::TARGET_DIMENSION
-      )
-
-      Rails.logger.info("=> [SEMANTIC_SEARCH] Validated embedding dimension: #{vector.length}")
-
-      embedding.embedding_vector = vector
-      embedding.content_hash = content_hash
-      embedding.model_used = Setting.plugin_semantic_search["embedding_model"]
-      embedding.original_dimension = original_dimension
-      embedding.save!
-
+      _generate_and_save_embedding(issue, embedding, content_hash, embedding_service)
       Rails.logger.info("=> [SEMANTIC_SEARCH] Successfully generated embedding for Issue ##{issue.id}")
     rescue StandardError => e
       Rails.logger.error("=> [SEMANTIC_SEARCH] Failed to generate embedding for Issue ##{issue.id}: #{e.message}")
       Rails.logger.error("=> [SEMANTIC_SEARCH] Error details: #{e.backtrace.join("\n")}")
       raise e
     end
+  end
+
+  def _generate_and_save_embedding(issue, embedding, content_hash, embedding_service)
+    content = embedding_service.prepare_issue_content(issue)
+    vector, original_dimension = embedding_service.generate_embedding(content)
+
+    log_msg = "=> [SEMANTIC_SEARCH] Generated embedding with dimension: #{vector.length}, " \
+              "original: #{original_dimension}"
+    Rails.logger.info(log_msg)
+
+    vector = DimensionReductionService.validate_vector_dimension(
+      vector,
+      EmbeddingService::TARGET_DIMENSION
+    )
+
+    Rails.logger.info("=> [SEMANTIC_SEARCH] Validated embedding dimension: #{vector.length}")
+
+    embedding.embedding_vector = vector
+    embedding.content_hash = content_hash
+    embedding.model_used = Setting.plugin_semantic_search["embedding_model"]
+    embedding.original_dimension = original_dimension
+    embedding.save!
   end
 end

--- a/app/jobs/issue_embedding_job.rb
+++ b/app/jobs/issue_embedding_job.rb
@@ -31,16 +31,27 @@ class IssueEmbeddingJob < ActiveJob::Base
     embedding_service = EmbeddingService.new
     begin
       content = embedding_service.prepare_issue_content(issue)
-      vector = embedding_service.generate_embedding(content)
+      vector, original_dimension = embedding_service.generate_embedding(content)
+
+      Rails.logger.info("=> [SEMANTIC_SEARCH] Generated embedding with dimension: #{vector.length}, original: #{original_dimension}")
+
+      vector = DimensionReductionService.validate_vector_dimension(
+        vector,
+        EmbeddingService::TARGET_DIMENSION
+      )
+
+      Rails.logger.info("=> [SEMANTIC_SEARCH] Validated embedding dimension: #{vector.length}")
 
       embedding.embedding_vector = vector
       embedding.content_hash = content_hash
       embedding.model_used = Setting.plugin_semantic_search["embedding_model"]
+      embedding.original_dimension = original_dimension
       embedding.save!
 
       Rails.logger.info("=> [SEMANTIC_SEARCH] Successfully generated embedding for Issue ##{issue.id}")
     rescue StandardError => e
       Rails.logger.error("=> [SEMANTIC_SEARCH] Failed to generate embedding for Issue ##{issue.id}: #{e.message}")
+      Rails.logger.error("=> [SEMANTIC_SEARCH] Error details: #{e.backtrace.join("\n")}")
       raise e
     end
   end

--- a/app/services/dimension_reduction_service.rb
+++ b/app/services/dimension_reduction_service.rb
@@ -1,0 +1,57 @@
+class DimensionReductionService
+  def self.reduce_dimensions(vector, source_dimension, target_dimension)
+    padded_vector = pad_vector(vector, source_dimension)
+
+    pca_like_reduction(padded_vector, target_dimension)
+  end
+
+  def self.pad_vector(vector, target_size)
+    return vector if vector.nil? || vector.length >= target_size
+
+    vector + Array.new(target_size - vector.length, 0.0)
+  end
+
+  def self.validate_vector_dimension(vector, target_dimension)
+    return nil if vector.nil?
+
+    if vector.length > target_dimension
+      vector.first(target_dimension)
+    elsif vector.length < target_dimension
+      pad_vector(vector, target_dimension)
+    else
+      vector
+    end
+  end
+
+  private
+
+  def self.pca_like_reduction(vector, target_dimension)
+    return vector.first(target_dimension) if vector.length <= target_dimension
+
+    importance = vector.map(&:abs)
+
+    top_dimensions_count = [target_dimension / 5, 1].max
+    top_indices = importance.each_with_index
+                            .sort_by { |val, _| -val }
+                            .first(top_dimensions_count)
+                            .map { |_, idx| idx }
+
+    remaining_count = target_dimension - top_indices.length
+    step_size = vector.length.to_f / remaining_count
+    uniform_indices = (0...remaining_count).map { |i| (i * step_size).to_i }
+
+    uniform_indices = uniform_indices.reject { |idx| top_indices.include?(idx) }
+
+    while (top_indices.length + uniform_indices.length) < target_dimension
+      idx = 0
+      while top_indices.include?(idx) || uniform_indices.include?(idx)
+        idx += 1
+      end
+      uniform_indices << idx
+    end
+
+    selected_indices = (top_indices + uniform_indices).sort
+
+    selected_indices.first(target_dimension).map { |idx| vector[idx] }
+  end
+end

--- a/app/services/semantic_search_result_processor.rb
+++ b/app/services/semantic_search_result_processor.rb
@@ -1,0 +1,44 @@
+module SemanticSearchResultProcessor
+  extend self
+
+  def process_results(results)
+    results.map do |result|
+      result = process_author_info(result)
+      result = process_assignee_info(result)
+      result = calculate_similarity_score(result)
+      remove_temporary_fields(result)
+    end
+  end
+
+  private
+
+  def process_author_info(result)
+    result["author_name"] = [result["author_firstname"], result["author_lastname"]].join(" ").strip
+    result["author_name"] = result["author_login"] if result["author_name"].blank?
+    result
+  end
+
+  def process_assignee_info(result)
+    if result["assigned_to_firstname"] || result["assigned_to_lastname"] || result["assigned_to_login"]
+      result["assigned_to_name"] = [result["assigned_to_firstname"], result["assigned_to_lastname"]].join(" ").strip
+      result["assigned_to_name"] = result["assigned_to_login"] if result["assigned_to_name"].blank?
+    else
+      result["assigned_to_name"] = nil
+    end
+    result
+  end
+
+  def calculate_similarity_score(result)
+    distance = result["distance"].to_f
+    result["similarity_score"] = 1.0 / (1.0 + distance)
+    result
+  end
+
+  def remove_temporary_fields(result)
+    %w[author_firstname author_lastname author_login assigned_to_firstname assigned_to_lastname assigned_to_login
+       distance].each do |key|
+      result.delete(key)
+    end
+    result
+  end
+end

--- a/app/services/semantic_search_service.rb
+++ b/app/services/semantic_search_service.rb
@@ -1,14 +1,20 @@
+require_relative "semantic_search_result_processor"
+
 class SemanticSearchService
+  include SemanticSearchResultProcessor
+
   def initialize
     @embedding_service = EmbeddingService.new
   end
 
-  def search(query, user, limit = 10, debug = false)
+  def search(query, user, limit = 10, _debug: false)
     Rails.logger.info("Performing semantic search for query: #{query}")
 
     query_embedding, original_dimension = @embedding_service.generate_embedding(query)
 
-    Rails.logger.info("Query embedding generated with dimension: #{query_embedding.length}, original: #{original_dimension}")
+    log_msg = "Query embedding generated with dim: #{query_embedding.length}, " \
+              "original: #{original_dimension}"
+    Rails.logger.info(log_msg)
 
     query_embedding = DimensionReductionService.validate_vector_dimension(
       query_embedding,
@@ -37,17 +43,19 @@ class SemanticSearchService
     sql.gsub(/ARRAY\[.*?\]::vector/, "ARRAY[...vector values...]::vector")
 
     begin
-      results = ActiveRecord::Base.connection.execute(sql)
-      results
-    rescue
+      ActiveRecord::Base.connection.execute(sql)
+    rescue StandardError
       begin
-        db_dimension = ActiveRecord::Base.connection.execute(
-          "SELECT pg_catalog.format_type(atttypid, atttypmod-4) FROM pg_catalog.pg_attribute WHERE attrelid = 'issue_embeddings'::regclass AND attname = 'embedding_vector'"
-        ).first["format_type"]
+        db_dim_query = <<~SQL.squish
+          SELECT pg_catalog.format_type(atttypid, atttypmod-4)
+          FROM pg_catalog.pg_attribute
+          WHERE attrelid = 'issue_embeddings'::regclass AND attname = 'embedding_vector'
+        SQL
+        db_dimension = ActiveRecord::Base.connection.execute(db_dim_query).first["format_type"]
 
         Rails.logger.error("Database column type: #{db_dimension}")
         Rails.logger.error("Provided vector length: #{query_embedding.length}")
-      rescue => debug_error
+      rescue StandardError => debug_error
         Rails.logger.error("Error getting debug info: #{debug_error.message}")
       end
 
@@ -55,8 +63,9 @@ class SemanticSearchService
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def build_search_sql(query_embedding, limit)
-    vector_string = query_embedding.join(',')
+    vector_string = query_embedding.join(",")
 
     <<-SQL
       SELECT issue_embeddings.issue_id,
@@ -89,45 +98,7 @@ class SemanticSearchService
       LIMIT #{limit}
     SQL
   end
-
-  def process_results(results)
-    results.map do |result|
-      result = process_author_info(result)
-      result = process_assignee_info(result)
-      result = calculate_similarity_score(result)
-      remove_temporary_fields(result)
-    end
-  end
-
-  def process_author_info(result)
-    result["author_name"] = [result["author_firstname"], result["author_lastname"]].join(" ").strip
-    result["author_name"] = result["author_login"] if result["author_name"].blank?
-    result
-  end
-
-  def process_assignee_info(result)
-    if result["assigned_to_firstname"] || result["assigned_to_lastname"] || result["assigned_to_login"]
-      result["assigned_to_name"] = [result["assigned_to_firstname"], result["assigned_to_lastname"]].join(" ").strip
-      result["assigned_to_name"] = result["assigned_to_login"] if result["assigned_to_name"].blank?
-    else
-      result["assigned_to_name"] = nil
-    end
-    result
-  end
-
-  def calculate_similarity_score(result)
-    distance = result["distance"].to_f
-    result["similarity_score"] = 1.0 / (1.0 + distance)
-    result
-  end
-
-  def remove_temporary_fields(result)
-    %w[author_firstname author_lastname author_login assigned_to_firstname assigned_to_lastname assigned_to_login
-       distance].each do |key|
-      result.delete(key)
-    end
-    result
-  end
+  # rubocop:enable Metrics/MethodLength
 
   def filter_by_visibility(processed_results, user)
     issue_ids = processed_results.map { |r| r["issue_id"] }

--- a/db/migrate/004_update_vector_dimension_for_pca.rb
+++ b/db/migrate/004_update_vector_dimension_for_pca.rb
@@ -1,0 +1,7 @@
+class UpdateVectorDimensionForPca < ActiveRecord::Migration[7.2]
+  def up
+    unless column_exists?(:issue_embeddings, :original_dimension)
+      add_column :issue_embeddings, :original_dimension, :integer, default: 1536
+    end
+  end
+end

--- a/db/migrate/005_add_pca_support_to_issue_embeddings.rb
+++ b/db/migrate/005_add_pca_support_to_issue_embeddings.rb
@@ -1,0 +1,15 @@
+class AddPcaSupportToIssueEmbeddings < ActiveRecord::Migration[7.2]
+  def up
+    execute "DROP INDEX IF EXISTS issue_embeddings_vector_idx"
+
+    execute "ALTER TABLE issue_embeddings ALTER COLUMN embedding_vector TYPE vector(2000)"
+
+    execute "CREATE INDEX issue_embeddings_vector_idx ON issue_embeddings USING ivfflat (embedding_vector vector_l2_ops) WITH (lists = 100)"
+  end
+
+  def down
+    execute "DROP INDEX IF EXISTS issue_embeddings_vector_idx"
+
+    execute "CREATE INDEX issue_embeddings_vector_idx ON issue_embeddings USING ivfflat (embedding_vector vector_l2_ops) WITH (lists = 100)"
+  end
+end

--- a/db/migrate/006_update_existing_embeddings_for_pca.rb
+++ b/db/migrate/006_update_existing_embeddings_for_pca.rb
@@ -1,0 +1,12 @@
+class UpdateExistingEmbeddingsForPca < ActiveRecord::Migration[7.2]
+  def up
+    return unless table_exists?(:issue_embeddings) &&
+                  column_exists?(:issue_embeddings, :embedding_vector)
+
+    unless column_exists?(:issue_embeddings, :original_dimension)
+      add_column :issue_embeddings, :original_dimension, :integer, default: 1536
+    end
+
+    execute "SELECT id, issue_id FROM issue_embeddings WHERE embedding_vector IS NOT NULL"
+  end
+end

--- a/scripts/embedding_viewer.py
+++ b/scripts/embedding_viewer.py
@@ -37,6 +37,7 @@ def fetch_embeddings(conn, limit=1000, project_id=None, issue_id=None):
         ie.id,
         ie.issue_id,
         ie.model_used,
+        ie.original_dimension,
         i.subject,
         p.name as project_name,
         t.name as tracker_name,

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -14,13 +14,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     fill_in 'username', with: login
     fill_in 'password', with: password
     click_button 'Login', wait: 5
-    assert_selector '#loggedas'
+    assert_selector '#loggedas', wait: 5
   end
 
   def logout
     if has_link?(class: 'logout')
-      click_link(class: 'logout')
+      click_link(class: 'logout', wait: 5)
     end
-    assert_no_selector '#loggedas'
+    assert_no_selector '#loggedas', wait: 5
   end
 end

--- a/test/integration/semantic_search_test.rb
+++ b/test/integration/semantic_search_test.rb
@@ -13,7 +13,7 @@ class SemanticSearchTest < Redmine::IntegrationTest
     @issue = Issue.find(1)
     @embedding = IssueEmbedding.create!(
       issue: @issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: 'test_hash',
       model_used: 'text-embedding-ada-002'
     )

--- a/test/system/semantic_search_system_test.rb
+++ b/test/system/semantic_search_system_test.rb
@@ -23,12 +23,12 @@ class SemanticSearchSystemTest < ApplicationSystemTestCase
 
     @embedding = IssueEmbedding.create!(
       issue: @issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: 'test_hash',
       model_used: 'text-embedding-ada-002'
     )
 
-    EmbeddingService.any_instance.stubs(:generate_embedding).returns([0.1] * 1536)
+    EmbeddingService.any_instance.stubs(:generate_embedding).returns([0.1] * 2000)
 
     mock_result = [{
       "issue_id" => @issue.id,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,13 @@ class EmbeddingServiceMock
   end
 
   def generate_embedding(text)
-    Array.new(1536) { 0.1 }
+    vector = Array.new(1536) { 0.1 }
+    reduced_vector = DimensionReductionService.reduce_dimensions(
+      DimensionReductionService.pad_vector(vector, 5500),
+      5500,
+      2000
+    )
+    return reduced_vector, 1536
   end
 
   def prepare_issue_content(issue)

--- a/test/unit/dimension_reduction_service_test.rb
+++ b/test/unit/dimension_reduction_service_test.rb
@@ -1,0 +1,61 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class DimensionReductionServiceTest < ActiveSupport::TestCase
+  def test_reduce_dimensions
+    vector = Array.new(3000) { rand }
+    source_dimension = 5500
+    target_dimension = 2000
+
+    padded_vector = DimensionReductionService.pad_vector(vector, source_dimension)
+    assert_equal source_dimension, padded_vector.length
+
+    reduced_vector = DimensionReductionService.reduce_dimensions(padded_vector, source_dimension, target_dimension)
+    assert_equal target_dimension, reduced_vector.length
+  end
+
+  def test_pca_like_reduction
+    vector_size = 5500
+    test_vector = Array.new(vector_size, 0.1)
+    important_positions = [10, 100, 1000, 2000, 3000, 4000, 5000]
+    important_positions.each do |pos|
+      test_vector[pos] = 0.9
+    end
+
+    target_dimension = 20
+    reduced_vector = DimensionReductionService.send(:pca_like_reduction, test_vector, target_dimension)
+
+    assert_equal target_dimension, reduced_vector.length
+
+    top_dimensions_count = [target_dimension / 5, 1].max
+
+    preserved_important = reduced_vector.count { |val| val.abs > 0.8 }
+
+    assert preserved_important > 0, "Should preserve at least one important dimension"
+  end
+
+  def test_pad_vector
+    vector = Array.new(100) { 0.5 }
+    target_size = 200
+
+    padded_vector = DimensionReductionService.pad_vector(vector, target_size)
+    assert_equal target_size, padded_vector.length
+
+    vector.each_with_index do |val, i|
+      assert_equal val, padded_vector[i]
+    end
+
+    (vector.length...target_size).each do |i|
+      assert_equal 0.0, padded_vector[i]
+    end
+  end
+
+  def test_pad_vector_no_padding_needed
+    vector = Array.new(100) { 0.5 }
+
+    padded_vector = DimensionReductionService.pad_vector(vector, 100)
+    assert_equal vector, padded_vector
+
+    padded_vector = DimensionReductionService.pad_vector(vector, 50)
+    assert_equal vector, padded_vector
+  end
+end

--- a/test/unit/embedding_service_test.rb
+++ b/test/unit/embedding_service_test.rb
@@ -48,8 +48,9 @@ class EmbeddingServiceTest < ActiveSupport::TestCase
       }
     ).returns(mock_response)
 
-    result = @service.generate_embedding("Test text")
-    assert_equal mock_embedding, result
+    result, original_dimension = @service.generate_embedding("Test text")
+    assert_equal 2000, result.length
+    assert_equal 1536, original_dimension
   end
 
   def test_generate_embedding_handles_error_response
@@ -75,6 +76,16 @@ class EmbeddingServiceTest < ActiveSupport::TestCase
     assert_raises(EmbeddingService::EmbeddingError) do
       @service.generate_embedding("Test text")
     end
+  end
+
+  def test_pad_embedding
+    vector = Array.new(1000) { 0.1 }
+    result = @service.pad_embedding(vector)
+    assert_equal EmbeddingService::MAX_DIMENSION, result.length
+
+    vector = Array.new(EmbeddingService::MAX_DIMENSION) { 0.1 }
+    result = @service.pad_embedding(vector)
+    assert_equal EmbeddingService::MAX_DIMENSION, result.length
   end
 
   def test_prepare_issue_content

--- a/test/unit/issue_embedding_job_test.rb
+++ b/test/unit/issue_embedding_job_test.rb
@@ -24,6 +24,7 @@ class IssueEmbeddingJobTest < ActiveSupport::TestCase
     embedding = IssueEmbedding.find_by(issue_id: @issue.id)
     assert_not_nil embedding
     assert_equal @issue.id, embedding.issue_id
+    assert_equal 1536, embedding.original_dimension
   end
 
   def test_job_does_nothing_when_disabled
@@ -48,9 +49,10 @@ class IssueEmbeddingJobTest < ActiveSupport::TestCase
     content_hash = IssueEmbedding.calculate_content_hash(@issue)
     original_embedding = IssueEmbedding.create!(
       issue_id: @issue.id,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: Array.new(2000) { 0.1 },
       content_hash: content_hash,
-      model_used: 'text-embedding-ada-002'
+      model_used: 'text-embedding-ada-002',
+      original_dimension: 1536
     )
 
     job = IssueEmbeddingJob.new

--- a/test/unit/issue_embedding_test.rb
+++ b/test/unit/issue_embedding_test.rb
@@ -7,7 +7,7 @@ class IssueEmbeddingTest < ActiveSupport::TestCase
     @issue = Issue.find(1)
     @embedding = IssueEmbedding.new(
       issue: @issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: 'test_hash',
       model_used: 'text-embedding-ada-002'
     )
@@ -29,7 +29,7 @@ class IssueEmbeddingTest < ActiveSupport::TestCase
     assert_not @embedding.valid?
     assert_includes @embedding.errors[:embedding_vector], 'cannot be blank'
 
-    @embedding.embedding_vector = [0.1] * 1536
+    @embedding.embedding_vector = [0.1] * 2000
     @embedding.content_hash = nil
     assert_not @embedding.valid?
     assert_includes @embedding.errors[:content_hash], 'cannot be blank'
@@ -93,7 +93,7 @@ class IssueEmbeddingTest < ActiveSupport::TestCase
     current_hash = IssueEmbedding.calculate_content_hash(issue)
     embedding = IssueEmbedding.create!(
       issue: issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: current_hash,
       model_used: 'text-embedding-ada-002'
     )


### PR DESCRIPTION
This PR will not be merged. I decided not to use PCA to decrease vector dim sizes from larger models down to 2000 dims, since I have observed a significant decrease in the quality of the search results.

The less keywords, the less accurate it was, even if there was an exact match of the query.

For example:

![CleanShot 2025-05-14 at 11 52 40](https://github.com/user-attachments/assets/0752e811-ce7c-4ab2-ba3c-e19edb386446)

The issue lies in the fact that we need to pad up Vectors that match the condition $$<5500$$ with $$0$$ s all the way up to $$5500$$. This is called Zero Padding. And after we do that, we then need to apply the maths of PCA, and only then do we have a vector ready for similarity search.

It is possible my implementation of PCA is inaccurate, as I am quite inexperienced in this. I tried to follow the [Wikipedia Article](https://en.wikipedia.org/wiki/Principal_component_analysis) as closely as possible.

> [!NOTE]
> Note: The reason why I don't just change the vector size of the embedding column in a new migration is: That's impossible. `pgvector` and PostgreSQL do not support vector dimensions larger than 2000 natively. There is a possibility of using a custom version, but it would be very hacky, and as I've read through threads about this problem, it seems PCA is the standard way to solve this issue, not to self-compose postgres.