### PR TITLE
Update max allowed vector dimension

### DIFF
--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -3,7 +3,7 @@ require "ruby/openai"
 class EmbeddingService
   class EmbeddingError < StandardError; end
 
-  MAX_DIMENSION = 1536
+  MAX_DIMENSION = 2000
 
   def initialize
     @client = OpenAI::Client.new(access_token: api_key, uri_base: base_url)
@@ -42,11 +42,9 @@ class EmbeddingService
       768
     when "text-embedding-ada-002" # openai
       1536
-    # rubocop:disable Lint/DuplicateBranch
     else
-      1536
+      2000
     end
-    # rubocop:enable Lint/DuplicateBranch
   end
 
   def prepare_issue_content(issue)

--- a/app/views/settings/_semantic_search_settings.html.erb
+++ b/app/views/settings/_semantic_search_settings.html.erb
@@ -30,6 +30,8 @@
                        ['text-embedding-ada-002 (Default)', 'text-embedding-ada-002'],
                        ['nomic-embed-text:latest (Ollama)', 'nomic-embed-text:latest']
                      ], settings['embedding_model'] || 'text-embedding-ada-002') %>
+
+      <em class="info"><%= l(:text_embedding_model_info) %></em>
     </p>
 
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,5 @@ en:
 
   error_openai_api_key_required: "OpenAI API key not found. Please set OPENAI_API_KEY environment variable."
   error_plugin_disabled: "Semantic Search is currently disabled. Please enable it in the plugin settings."
+
+  text_embedding_model_info: "Make sure the model you choose has an output vector dimension of 2000 or less, and supports the OpenAI API Specification."

--- a/db/migrate/004_change_max_vector_size.rb
+++ b/db/migrate/004_change_max_vector_size.rb
@@ -1,0 +1,13 @@
+class ChangeMaxVectorSize < ActiveRecord::Migration[7.2]
+  def up
+    execute "DROP INDEX IF EXISTS issue_embeddings_vector_idx"
+    execute "ALTER TABLE issue_embeddings ALTER COLUMN embedding_vector TYPE vector(2000)"
+    execute "CREATE INDEX issue_embeddings_vector_idx ON issue_embeddings USING ivfflat (embedding_vector vector_l2_ops) WITH (lists = 100)"
+  end
+
+  def down
+    execute "DROP INDEX IF EXISTS issue_embeddings_vector_idx"
+    execute "ALTER TABLE issue_embeddings ALTER COLUMN embedding_vector TYPE vector(1536)"
+    execute "CREATE INDEX issue_embeddings_vector_idx ON issue_embeddings USING ivfflat (embedding_vector vector_l2_ops) WITH (lists = 100)"
+  end
+end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -6,7 +6,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   setup do
-    EmbeddingService.any_instance.stubs(:generate_embedding).returns(Array.new(1536) { 0.1 })
+    EmbeddingService.any_instance.stubs(:generate_embedding).returns(Array.new(2000) { 0.1 })
   end
 
   def log_user(login, password)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -13,14 +13,14 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     visit '/login'
     fill_in 'username', with: login
     fill_in 'password', with: password
-    click_button 'Login', wait: 5
-    assert_selector '#loggedas', wait: 5
+    click_button 'Login', wait: 3
+    assert_selector '#loggedas', wait: 3
   end
 
   def logout
     if has_link?(class: 'logout')
-      click_link(class: 'logout', wait: 5)
+      click_link(class: 'logout', wait: 3)
     end
-    assert_no_selector '#loggedas', wait: 5
+    assert_no_selector '#loggedas', wait: 3
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -14,13 +14,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     fill_in 'username', with: login
     fill_in 'password', with: password
     click_button 'Login', wait: 5
-    assert_selector '#loggedas'
+    assert_selector '#loggedas', wait: 5
   end
 
   def logout
     if has_link?(class: 'logout')
-      click_link(class: 'logout')
+      click_link(class: 'logout', wait: 5)
     end
-    assert_no_selector '#loggedas'
+    assert_no_selector '#loggedas', wait: 5
   end
 end

--- a/test/integration/semantic_search_test.rb
+++ b/test/integration/semantic_search_test.rb
@@ -13,7 +13,7 @@ class SemanticSearchTest < Redmine::IntegrationTest
     @issue = Issue.find(1)
     @embedding = IssueEmbedding.create!(
       issue: @issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: 'test_hash',
       model_used: 'text-embedding-ada-002'
     )

--- a/test/system/semantic_search_system_test.rb
+++ b/test/system/semantic_search_system_test.rb
@@ -23,12 +23,12 @@ class SemanticSearchSystemTest < ApplicationSystemTestCase
 
     @embedding = IssueEmbedding.create!(
       issue: @issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: 'test_hash',
       model_used: 'text-embedding-ada-002'
     )
 
-    EmbeddingService.any_instance.stubs(:generate_embedding).returns([0.1] * 1536)
+    EmbeddingService.any_instance.stubs(:generate_embedding).returns([0.1] * 2000)
 
     mock_result = [{
       "issue_id" => @issue.id,

--- a/test/system/semantic_search_system_test.rb
+++ b/test/system/semantic_search_system_test.rb
@@ -119,7 +119,7 @@ class SemanticSearchSystemTest < ApplicationSystemTestCase
     visit '/'
 
     within '#top-menu' do
-      assert_no_link I18n.t(:label_semantic_search)
+      assert_no_link I18n.t(:label_semantic_search), wait: 5
     end
   end
 end

--- a/test/system/semantic_search_system_test.rb
+++ b/test/system/semantic_search_system_test.rb
@@ -74,7 +74,7 @@ class SemanticSearchSystemTest < ApplicationSystemTestCase
       click_button 'Search'
     end
 
-    assert_selector 'dl#search-results-list', wait: 5
+    assert_selector 'dl#search-results-list', wait: 3
 
     assert_selector "dt a[href='/issues/#{@issue.id}']"
 
@@ -96,7 +96,7 @@ class SemanticSearchSystemTest < ApplicationSystemTestCase
       click_button 'Search'
     end
 
-    assert_selector 'p.nodata', wait: 5
+    assert_selector 'p.nodata', wait: 3
   end
 
   test "semantic search page is accessible only to authorized users" do
@@ -119,7 +119,7 @@ class SemanticSearchSystemTest < ApplicationSystemTestCase
     visit '/'
 
     within '#top-menu' do
-      assert_no_link I18n.t(:label_semantic_search), wait: 5
+      assert_no_link I18n.t(:label_semantic_search), wait: 3
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ class EmbeddingServiceMock
   end
 
   def generate_embedding(text)
-    Array.new(1536) { 0.1 }
+    Array.new(2000) { 0.1 }
   end
 
   def prepare_issue_content(issue)

--- a/test/unit/embedding_service_test.rb
+++ b/test/unit/embedding_service_test.rb
@@ -24,7 +24,7 @@ class EmbeddingServiceTest < ActiveSupport::TestCase
   end
 
   def test_generate_embedding
-    mock_embedding = Array.new(1536) { rand }
+    mock_embedding = Array.new(2000) { rand }
     mock_response = {
       "data" => [
         {

--- a/test/unit/issue_embedding_job_test.rb
+++ b/test/unit/issue_embedding_job_test.rb
@@ -48,7 +48,7 @@ class IssueEmbeddingJobTest < ActiveSupport::TestCase
     content_hash = IssueEmbedding.calculate_content_hash(@issue)
     original_embedding = IssueEmbedding.create!(
       issue_id: @issue.id,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: content_hash,
       model_used: 'text-embedding-ada-002'
     )

--- a/test/unit/issue_embedding_test.rb
+++ b/test/unit/issue_embedding_test.rb
@@ -7,7 +7,7 @@ class IssueEmbeddingTest < ActiveSupport::TestCase
     @issue = Issue.find(1)
     @embedding = IssueEmbedding.new(
       issue: @issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: 'test_hash',
       model_used: 'text-embedding-ada-002'
     )
@@ -29,7 +29,7 @@ class IssueEmbeddingTest < ActiveSupport::TestCase
     assert_not @embedding.valid?
     assert_includes @embedding.errors[:embedding_vector], 'cannot be blank'
 
-    @embedding.embedding_vector = [0.1] * 1536
+    @embedding.embedding_vector = [0.1] * 2000
     @embedding.content_hash = nil
     assert_not @embedding.valid?
     assert_includes @embedding.errors[:content_hash], 'cannot be blank'
@@ -93,7 +93,7 @@ class IssueEmbeddingTest < ActiveSupport::TestCase
     current_hash = IssueEmbedding.calculate_content_hash(issue)
     embedding = IssueEmbedding.create!(
       issue: issue,
-      embedding_vector: [0.1] * 1536,
+      embedding_vector: [0.1] * 2000,
       content_hash: current_hash,
       model_used: 'text-embedding-ada-002'
     )

--- a/test/unit/semantic_search_service_test.rb
+++ b/test/unit/semantic_search_service_test.rb
@@ -10,7 +10,7 @@ class SemanticSearchServiceTest < ActiveSupport::TestCase
     @service = SemanticSearchService.new
     @user = User.find(1)
     @query = "test search query"
-    @query_embedding = Array.new(1536) { rand }
+    @query_embedding = Array.new(2000) { rand }
   end
 
   def test_search
@@ -19,7 +19,7 @@ class SemanticSearchServiceTest < ActiveSupport::TestCase
     issue = Issue.find(1)
     embedding = IssueEmbedding.new(
       issue: issue,
-      embedding_vector: Array.new(1536) { rand },
+      embedding_vector: Array.new(2000) { rand },
       content_hash: 'test_hash',
       model_used: 'text-embedding-ada-002'
     )
@@ -79,7 +79,7 @@ class SemanticSearchServiceTest < ActiveSupport::TestCase
 
     visible_embedding = IssueEmbedding.new(
       issue: visible_issue,
-      embedding_vector: Array.new(1536) { rand },
+      embedding_vector: Array.new(2000) { rand },
       content_hash: 'visible_hash',
       model_used: 'text-embedding-ada-002'
     )
@@ -87,7 +87,7 @@ class SemanticSearchServiceTest < ActiveSupport::TestCase
 
     invisible_embedding = IssueEmbedding.new(
       issue: invisible_issue,
-      embedding_vector: Array.new(1536) { rand },
+      embedding_vector: Array.new(2000) { rand },
       content_hash: 'invisible_hash',
       model_used: 'text-embedding-ada-002'
     )


### PR DESCRIPTION
We want to set the maximum allowed Vector Dimensions to $$2000$$ since most embedding models generate below that. There are ones that generate more. Here is a proof of concept PR in regards to larger output sizes: https://github.com/renuo/redmine_semantic_search/pull/18

I also added a note:

![CleanShot 2025-05-14 at 14 31 18](https://github.com/user-attachments/assets/7a16a1de-5599-4d74-b7af-0652c19bd1b7)