### PR TITLE
Test plugin with two Redmine versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        redmine_version: ["6.0", "5.1"]
+        redmine_version: ["6.0-stable", "5.1-stable"]
     env:
       RAILS_ENV: test
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        redmine_version: ["6.0", "5.1"]
     env:
       RAILS_ENV: test
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       PGHOST: localhost
       PGUSER: postgres
       PGPASSWORD: postgres
-      REDMINE_VERSION: 6.0.5
+      REDMINE_VERSION: ${{ matrix.redmine_version }}
 
     services:
       postgres:
@@ -35,7 +38,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: redmine
-          key: redmine-${{ env.REDMINE_VERSION }}
+          key: redmine-${{ matrix.redmine_version }}
 
       - name: Checkout redmine repository
         if: steps.cache-redmine.outputs.cache-hit != 'true'
@@ -43,7 +46,7 @@ jobs:
         with:
           repository: redmine/redmine
           path: redmine
-          ref: ${{ env.REDMINE_VERSION }}
+          ref: ${{ matrix.redmine_version }}
 
       - name: Checkout plugin
         uses: actions/checkout@v4

--- a/db/migrate/001_create_issue_embeddings.rb
+++ b/db/migrate/001_create_issue_embeddings.rb
@@ -1,4 +1,4 @@
-class CreateIssueEmbeddings < ActiveRecord::Migration[7.2]
+class CreateIssueEmbeddings < ActiveRecord::Migration[6.1]
   def up
     execute "CREATE EXTENSION IF NOT EXISTS vector"
 

--- a/db/migrate/002_install_neighbor_vector.rb
+++ b/db/migrate/002_install_neighbor_vector.rb
@@ -1,4 +1,4 @@
-class InstallNeighborVector < ActiveRecord::Migration[7.2]
+class InstallNeighborVector < ActiveRecord::Migration[6.1]
   def change
     enable_extension "vector"
   end

--- a/db/migrate/003_add_model_used.rb
+++ b/db/migrate/003_add_model_used.rb
@@ -1,4 +1,4 @@
-class AddModelUsed < ActiveRecord::Migration[7.2]
+class AddModelUsed < ActiveRecord::Migration[6.1]
   def change
     add_column :issue_embeddings, :model_used, :string
   end

--- a/db/migrate/004_change_max_vector_size.rb
+++ b/db/migrate/004_change_max_vector_size.rb
@@ -1,4 +1,4 @@
-class ChangeMaxVectorSize < ActiveRecord::Migration[7.2]
+class ChangeMaxVectorSize < ActiveRecord::Migration[6.1]
   def up
     execute "DROP INDEX IF EXISTS issue_embeddings_vector_idx"
     execute "ALTER TABLE issue_embeddings ALTER COLUMN embedding_vector TYPE vector(2000)"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -16,13 +16,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     fill_in 'username', with: login
     fill_in 'password', with: password
     click_button 'Login', wait: 3
-    assert_selector '#loggedas', wait: 3
+    assert_selector '#loggedas', wait: 5
   end
 
   def logout
     if has_link?(class: 'logout')
       click_link(class: 'logout', wait: 3)
     end
-    assert_no_selector '#loggedas', wait: 3
+    assert_no_selector '#loggedas', wait: 5
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,6 +5,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     driver_options.add_argument 'disable-gpu'
   end
 
+  include LoginHelpers::System
+
   setup do
     EmbeddingService.any_instance.stubs(:generate_embedding).returns(Array.new(2000) { 0.1 })
   end

--- a/test/integration/issue_creation_with_embedding_test.rb
+++ b/test/integration/issue_creation_with_embedding_test.rb
@@ -2,6 +2,7 @@ require File.expand_path('../../test_helper', __FILE__)
 
 class IssueCreationWithEmbeddingTest < Redmine::IntegrationTest
   include ActiveJob::TestHelper
+  include LoginHelpers::Integration
   fixtures :projects, :users, :roles, :members, :member_roles, :trackers, :issue_statuses
 
   def setup
@@ -94,19 +95,5 @@ class IssueCreationWithEmbeddingTest < Redmine::IntegrationTest
     SemanticSearch::IssueHooks.instance.singleton_class.class_eval do
       define_method(:plugin_enabled?, original_method)
     end
-  end
-
-  private
-
-  def log_user(login, password)
-    get '/login'
-    assert_response :success
-    post '/login', params: {
-      username: login,
-      password: password
-    }
-    assert_redirected_to '/my/page'
-    follow_redirect!
-    assert_equal login, User.find(session[:user_id]).login
   end
 end

--- a/test/integration/semantic_search_test.rb
+++ b/test/integration/semantic_search_test.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class SemanticSearchTest < Redmine::IntegrationTest
+  include LoginHelpers::Integration
   fixtures :projects, :users, :roles, :members, :member_roles, :issues, :trackers
 
   def setup
@@ -66,19 +67,5 @@ class SemanticSearchTest < Redmine::IntegrationTest
 
     get '/semantic_search'
     assert_response :forbidden
-  end
-
-  private
-
-  def log_user(login, password)
-    get '/login'
-    assert_response :success
-    post '/login', params: {
-      username: login,
-      password: password
-    }
-    assert_redirected_to '/my/page'
-    follow_redirect!
-    assert_equal login, User.find(session[:user_id]).login
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,3 +26,37 @@ end
 ActiveSupport::TestCase.setup do |test|
   # TODO: implement?
 end
+
+# Login helper methods for different test types
+module LoginHelpers
+  module Integration
+    def log_user(login, password)
+      get '/login'
+      assert_response :success
+      post '/login', params: {
+        username: login,
+        password: password
+      }
+      assert_redirected_to '/my/page'
+      follow_redirect!
+      assert_equal login, User.find(session[:user_id]).login
+    end
+  end
+
+  module System
+    def log_user(login, password)
+      visit '/login'
+      fill_in 'username', with: login
+      fill_in 'password', with: password
+      click_button 'Login', wait: 3
+      assert_selector '#loggedas', wait: 3
+    end
+
+    def logout
+      if has_link?(class: 'logout')
+        click_link(class: 'logout', wait: 3)
+      end
+      assert_no_selector '#loggedas', wait: 3
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the test GitHub actions file, so that the plugin tests are ran with Redmine Versions 5.1 and 6.0, since it is required to work with them.

Available versions/branches can be found here: https://github.com/redmine/redmine/branches

However in the end, github.com/redmine/redmine is just a mirror, so it could end up being slightly out of date (which is not a problem for our specific use-case).