### PR TITLE
Fix setup script and instructions

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -141,12 +141,7 @@ To quickly populate your Redmine instance with sample projects and issues for te
     cd path/to/your/redmine/plugins/redmine_semantic_search
     ```
 
-3.  **Make the script executable (if you haven't already):**
-    ```bash
-    chmod +x bin/setup
-    ```
-
-4.  **Run the setup script:**
+3.  **Run the setup script:**
     You must specify the `RAILS_ENV` (it defaults to `development`). Next, run this command:
     ```bash
     RAILS_ENV=production ./bin/setup

--- a/bin/setup
+++ b/bin/setup
@@ -40,7 +40,8 @@ echo "Changed directory to ${REDMINE_ROOT}"
 
 echo "Ensuring Redmine gems are installed (running bundle install)..."
 bundle check || bundle install
-bundle exec rake db:create db:migrate db:seed redmine:load_default_data
+bundle exec rake db:create db:migrate db:seed redmine:load_default_data REDMINE_LANG=en
+bundle exec rake redmine:plugins:migrate
 
 RAKE_TASK="redmine_semantic_search:setup_dev_data"
 RAILS_ENV="${RAILS_ENV:-development}"

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 command_exists() {
   command -v "$1" >/dev/null 2>&1
@@ -32,12 +32,15 @@ if ! command_exists bundle; then
   fi
 fi
 
+cp -n config/database.yml.example "${REDMINE_ROOT}/config/database.yml"
+
 cd "${REDMINE_ROOT}"
 
 echo "Changed directory to ${REDMINE_ROOT}"
 
 echo "Ensuring Redmine gems are installed (running bundle install)..."
 bundle check || bundle install
+bundle exec rake db:create db:migrate db:seed redmine:load_default_data
 
 RAKE_TASK="redmine_semantic_search:setup_dev_data"
 RAILS_ENV="${RAILS_ENV:-development}"

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,0 +1,18 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+development:
+  <<: *default
+  database: redmine_development
+
+test:
+  <<: *default
+  database: redmine_test
+
+production:
+  <<: *default
+  url: <%= ENV["DATABASE_URL"] %>


### PR DESCRIPTION
The setup instructions are still much too verbose for my taste (they look very ChatGPT generated IMO), but at least now the `bin/setup` script works.