### PR TITLE
Don't fail fast with integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         redmine_version: ["6.0-stable", "5.1-stable"]
     env:


### PR DESCRIPTION
I always want to execute both, so I see when a failure affects both Redmine versions.