### PR TITLE
Drop Redmine 5.1 from CI and add 6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: ["6.0-stable", "5.1-stable"]
+        redmine_version: ["6.0-stable", "6.1-stable"]
     env:
       RAILS_ENV: test
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/test/system/redmine_semantic_search_system_test.rb
+++ b/test/system/redmine_semantic_search_system_test.rb
@@ -94,10 +94,10 @@ class RedmineSemanticSearchSystemTest < ApplicationSystemTestCase
 
     within '#redmine-semantic-search-form' do
       fill_in 'q', with: 'query with no results'
-      click_button 'Search', wait: 3
+      click_button 'Search'
     end
 
-    assert_selector 'p.nodata', wait: 3
+    assert_selector 'p.nodata', wait: 5
   end
 
   test "semantic search page is accessible only to authorized users" do


### PR DESCRIPTION
Also deleted 5.1 from the "require status checks to pass" repo setting

<img width="1039" height="667" alt="image" src="https://github.com/user-attachments/assets/f07e22ff-ce7f-4eb7-969d-14ce811b268e" />