### PR TITLE
Make the OpenAI API key optional for self-hosted endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the rendered Mermaid Domain Model, have a look at [this file](repo/domain_mo
 ## Requirements
 
 - PostgreSQL installed
-- Valid OpenAI API key
+- A valid OpenAI API key (only when using OpenAI, not needed for self-hosted Ollama)
 
 More information in [Setup Guide](#installation).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -78,17 +78,9 @@ Ollama allows you to run large language models locally. This is a great option f
     *   **Base URL:** `http://localhost:11434/v1`
     *   **Embedding Model:** `nomic-embed-text:latest`
 
-3.  **Set API Key for Ollama:**
-    For the connection to work correctly with Ollama, the `OPENAI_API_KEY` must be set to `ollama`.
-    It's recommended to create a `.env` file in your Redmine root directory and add the following line:
-    ```env
-    OPENAI_API_KEY=ollama
-    ```
-    Then, ensure your Redmine server loads this `.env` file (e.g., by using a gem like `dotenv-rails`).
-    Alternatively, you can set this in your shell profile (e.g., `.zshrc`, `.bashrc`) or when starting your Redmine server:
-    ```bash
-    OPENAI_API_KEY=ollama bundle exec rails server
-    ```
+3.  **No API Key needed:**
+    Ollama requires no authentication, so you can leave `OPENAI_API_KEY` unset.
+    A key is only required when using OpenAI (see Option 2 below).
 
 ### Option 2: Using OpenAI
 

--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -4,6 +4,7 @@ class EmbeddingService
   class EmbeddingError < StandardError; end
 
   MAX_DIMENSION = 2000
+  DEFAULT_BASE_URL = "https://api.openai.com/v1".freeze
 
   def initialize
     @client = OpenAI::Client.new(access_token: api_key, uri_base: base_url)
@@ -60,13 +61,19 @@ class EmbeddingService
 
   def api_key
     key = ENV.fetch("OPENAI_API_KEY", nil)
-    raise EmbeddingError, I18n.t("error_redmine_semantic_search_openai_api_key_required") if key.blank?
+    return key if key.present?
+    # Self-hosted, OpenAI-compatible endpoints (e.g. Ollama) need no key.
+    return nil if using_custom_base_url?
 
-    key
+    raise EmbeddingError, I18n.t("error_redmine_semantic_search_openai_api_key_required")
   end
 
   def base_url
-    Setting.plugin_redmine_semantic_search["base_url"] || "https://api.openai.com/v1"
+    @base_url ||= Setting.plugin_redmine_semantic_search["base_url"] || DEFAULT_BASE_URL
+  end
+
+  def using_custom_base_url?
+    base_url.to_s.strip.chomp("/") != DEFAULT_BASE_URL
   end
 
   def embedding_model

--- a/test/unit/embedding_service_test.rb
+++ b/test/unit/embedding_service_test.rb
@@ -23,6 +23,19 @@ class EmbeddingServiceTest < ActiveSupport::TestCase
     end
   end
 
+  def test_does_not_require_api_key_for_custom_base_url
+    ENV.delete("OPENAI_API_KEY")
+    original_settings = Setting.plugin_redmine_semantic_search
+    Setting.plugin_redmine_semantic_search = { "base_url" => "http://localhost:11434/v1" }
+
+    service = nil
+    assert_nothing_raised { service = EmbeddingService.new }
+    # Self-hosted, OpenAI-compatible endpoints (e.g. Ollama) need no key: none is sent.
+    assert_nil service.send(:api_key)
+  ensure
+    Setting.plugin_redmine_semantic_search = original_settings
+  end
+
   def test_generate_embedding
     mock_embedding = Array.new(2000) { rand }
     mock_response = {


### PR DESCRIPTION
When a custom `base_url` is set (e.g. a self-hosted Ollama instance), no API key is required. The default OpenAI URL still requires a key.

This removes the need for the `OPENAI_API_KEY=ollama` workaround in SETUP.md.