### PR TITLE
Support Basic Auth for self-hosted endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For the rendered Mermaid Domain Model, have a look at [this file](repo/domain_mo
 
 - PostgreSQL installed
 - A valid OpenAI API key (only when using OpenAI, not needed for self-hosted Ollama)
+- For a self-hosted endpoint behind Basic Auth, set `OLLAMA_BASIC_AUTH_USERNAME` and `OLLAMA_BASIC_AUTH_PASSWORD` (see [Setup Guide](SETUP.md))
 
 More information in [Setup Guide](#installation).
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -82,6 +82,16 @@ Ollama allows you to run large language models locally. This is a great option f
     Ollama requires no authentication, so you can leave `OPENAI_API_KEY` unset.
     A key is only required when using OpenAI (see Option 2 below).
 
+4.  **Protected self-hosted endpoint (optional):**
+    If your Ollama is hosted remotely with basic auth enabled,
+    provide the credentials via environment variables.
+    ```bash
+    export OLLAMA_BASIC_AUTH_USERNAME="your-username"
+    export OLLAMA_BASIC_AUTH_PASSWORD="your-password"
+    ```
+    Both must be set; if only one is present, basic auth is skipped. Leave both
+    unset for a local, unprotected Ollama.
+
 ### Option 2: Using OpenAI
 
 If you prefer to use OpenAI's models for embeddings:

--- a/app/services/embedding_service.rb
+++ b/app/services/embedding_service.rb
@@ -1,4 +1,5 @@
 require "ruby/openai"
+require "base64"
 
 class EmbeddingService
   class EmbeddingError < StandardError; end
@@ -7,7 +8,7 @@ class EmbeddingService
   DEFAULT_BASE_URL = "https://api.openai.com/v1".freeze
 
   def initialize
-    @client = OpenAI::Client.new(access_token: api_key, uri_base: base_url)
+    @client = OpenAI::Client.new(access_token: api_key, uri_base: base_url, extra_headers: extra_headers)
   end
 
   def generate_embedding(text)
@@ -74,6 +75,28 @@ class EmbeddingService
 
   def using_custom_base_url?
     base_url.to_s.strip.chomp("/") != DEFAULT_BASE_URL
+  end
+
+  def extra_headers
+    header = basic_auth_header
+    return {} if header.nil?
+
+    { "Authorization" => header }
+  end
+
+  def basic_auth_header
+    return nil unless using_custom_base_url?
+
+    username = ENV.fetch("OLLAMA_BASIC_AUTH_USERNAME", nil)
+    password = ENV.fetch("OLLAMA_BASIC_AUTH_PASSWORD", nil)
+    return nil if username.blank? && password.blank?
+
+    if username.blank? || password.blank?
+      Rails.logger.warn("Ignoring basic auth: set both OLLAMA_BASIC_AUTH_USERNAME and OLLAMA_BASIC_AUTH_PASSWORD")
+      return nil
+    end
+
+    "Basic #{Base64.strict_encode64("#{username}:#{password}")}"
   end
 
   def embedding_model

--- a/test/unit/embedding_service_test.rb
+++ b/test/unit/embedding_service_test.rb
@@ -235,13 +235,82 @@ class EmbeddingServiceTest < ActiveSupport::TestCase
     assert_equal 4, content.lines.count
   end
 
+  def test_basic_auth_header_nil_with_only_username
+    original_settings = Setting.plugin_redmine_semantic_search
+    Setting.plugin_redmine_semantic_search = { "base_url" => "http://localhost:11434/v1" }
+    ENV["OLLAMA_BASIC_AUTH_USERNAME"] = "user"
+
+    service = EmbeddingService.new
+    assert_nil service.send(:basic_auth_header)
+  ensure
+    Setting.plugin_redmine_semantic_search = original_settings
+    ENV.delete("OLLAMA_BASIC_AUTH_USERNAME")
+  end
+
+  def test_basic_auth_header_nil_with_only_password
+    original_settings = Setting.plugin_redmine_semantic_search
+    Setting.plugin_redmine_semantic_search = { "base_url" => "http://localhost:11434/v1" }
+    ENV["OLLAMA_BASIC_AUTH_PASSWORD"] = "pass"
+
+    service = EmbeddingService.new
+    assert_nil service.send(:basic_auth_header)
+  ensure
+    Setting.plugin_redmine_semantic_search = original_settings
+    ENV.delete("OLLAMA_BASIC_AUTH_PASSWORD")
+  end
+
+  def test_basic_auth_header_nil_on_default_url
+    original_settings = Setting.plugin_redmine_semantic_search
+    Setting.plugin_redmine_semantic_search = {}
+    ENV["OLLAMA_BASIC_AUTH_USERNAME"] = "user"
+    ENV["OLLAMA_BASIC_AUTH_PASSWORD"] = "pass"
+
+    service = EmbeddingService.new
+    assert_nil service.send(:basic_auth_header)
+  ensure
+    Setting.plugin_redmine_semantic_search = original_settings
+    ENV.delete("OLLAMA_BASIC_AUTH_USERNAME")
+    ENV.delete("OLLAMA_BASIC_AUTH_PASSWORD")
+  end
+
+  def test_basic_auth_header_does_not_warn_when_both_vars_unset
+    original_settings = Setting.plugin_redmine_semantic_search
+    Setting.plugin_redmine_semantic_search = { "base_url" => "http://localhost:11434/v1" }
+
+    service = EmbeddingService.new
+    Rails.logger.expects(:warn).never
+    assert_nil service.send(:basic_auth_header)
+  ensure
+    Setting.plugin_redmine_semantic_search = original_settings
+  end
+
+  def test_initialize_passes_basic_auth_header_when_configured
+    original_settings = Setting.plugin_redmine_semantic_search
+    custom_url = "http://localhost:11434/v1"
+    Setting.plugin_redmine_semantic_search = { "base_url" => custom_url }
+    ENV["OLLAMA_BASIC_AUTH_USERNAME"] = "user"
+    ENV["OLLAMA_BASIC_AUTH_PASSWORD"] = "pass"
+
+    OpenAI::Client.expects(:new).with(
+      access_token: "test_api_key",
+      uri_base: custom_url,
+      extra_headers: { "Authorization" => "Basic dXNlcjpwYXNz" }
+    ).returns(mock("OpenAI::Client"))
+    assert_not_nil EmbeddingService.new
+  ensure
+    Setting.plugin_redmine_semantic_search = original_settings
+    ENV.delete("OLLAMA_BASIC_AUTH_USERNAME")
+    ENV.delete("OLLAMA_BASIC_AUTH_PASSWORD")
+  end
+
   def test_base_url_uses_setting_if_present
     original_settings = Setting.plugin_redmine_semantic_search
     custom_url = "http://localhost:8080/v1"
     Setting.plugin_redmine_semantic_search = { "base_url" => custom_url }
 
     OpenAI::Client.expects(:new).with(access_token: "test_api_key",
-                                      uri_base: custom_url).returns(mock("OpenAI::Client"))
+                                      uri_base: custom_url,
+                                      extra_headers: {}).returns(mock("OpenAI::Client"))
     service = EmbeddingService.new
     assert_not_nil service, "Service should be initialized"
   ensure
@@ -256,7 +325,8 @@ class EmbeddingServiceTest < ActiveSupport::TestCase
     default_url = "https://api.openai.com/v1"
 
     OpenAI::Client.expects(:new).with(access_token: "test_api_key",
-                                      uri_base: default_url).returns(mock("OpenAI::Client"))
+                                      uri_base: default_url,
+                                      extra_headers: {}).returns(mock("OpenAI::Client"))
     service = EmbeddingService.new
     assert_not_nil service, "Service should be initialized"
   ensure
@@ -271,7 +341,8 @@ class EmbeddingServiceTest < ActiveSupport::TestCase
     default_url = "https://api.openai.com/v1"
 
     OpenAI::Client.expects(:new).with(access_token: "test_api_key",
-                                      uri_base: default_url).returns(mock("OpenAI::Client"))
+                                      uri_base: default_url,
+                                      extra_headers: {}).returns(mock("OpenAI::Client"))
     service = EmbeddingService.new
     assert_not_nil service, "Service should be initialized"
   ensure


### PR DESCRIPTION
Ollama is also hosted on [deploio](https://cockpit.nine.ch/en/renuo/deploio/management/projects/renuo-ollama-selfhost?namespace=renuo) now

Here are some examples:
<img width="1703" height="836" alt="image" src="https://github.com/user-attachments/assets/63e4c390-592b-4625-87fd-1b37a66ee2e0" />

<img width="1702" height="843" alt="image" src="https://github.com/user-attachments/assets/c86f43de-1e0d-4e76-8991-7301880a1d48" />

<img width="1718" height="847" alt="image" src="https://github.com/user-attachments/assets/730775ce-1e3b-433d-bd43-2b4bb0d8bc62" />
